### PR TITLE
Setup @babel/plugin-transform-runtime properly with @babel/runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,10 @@ module.exports = api => {
     ]
   ];
 
-  const plugins = ['@babel/plugin-proposal-export-default-from'];
+  const plugins = [
+    '@babel/plugin-proposal-export-default-from',
+    '@babel/plugin-transform-runtime',
+  ];
 
   return { presets, plugins };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2753,8 +2753,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc=",
-      "dev": true
+      "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -787,6 +787,26 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz",
+      "integrity": "sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
@@ -2100,6 +2120,15 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-reference": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
+      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39"
+      }
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-regex/-/is-regex-1.0.5.tgz",
@@ -2259,6 +2288,15 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -2882,6 +2920,19 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-commonjs": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "5.2.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
@@ -3018,6 +3069,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,7 +950,6 @@
       "version": "7.9.2",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/runtime/-/runtime-7.9.2.tgz",
       "integrity": "sha1-2Q3wWDo6JS8JqqYZZlNnuuUY2wY=",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
-    "@babel/runtime": "^7.9.2",
     "babel": "^6.23.0",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
@@ -43,6 +42,7 @@
     "rollup-plugin-uglify": "^6.0.4"
   },
   "dependencies": {
+    "@babel/runtime": "^7.9.2",
     "isomorphic-fetch": "^2.2.1",
     "pako": "^1.0.11",
     "tdigest": "latest"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
     "babel": "^6.23.0",
@@ -38,6 +39,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^1.20.0",
     "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-uglify": "^6.0.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
 import { uglify } from 'rollup-plugin-uglify';
 
 export default {
@@ -17,7 +18,11 @@ export default {
       main: true,
       browser: true
     }),
-    babel(),
+    babel({
+      exclude: ['node_modules/**'],
+      runtimeHelpers: true
+    }),
+    commonjs(),
     uglify()
   ]
 };


### PR DESCRIPTION
@babel/runtime is actually meant to be used with this plugin, per <https://babeljs.io/docs/en/babel-plugin-transform-runtime>

This gives us the nice ability of `require()`-ing the library as-is, ie. without passing `-r regenerator-runtime` as an argument to node.